### PR TITLE
templates: rework LLDP neighbor polling to walk[] + dependent items (fixes FortiGate timemark churn and MikroTik noSuchObject)

### DIFF
--- a/templates/nt_lldp_snmp_template.yaml
+++ b/templates/nt_lldp_snmp_template.yaml
@@ -10,7 +10,7 @@ zabbix_export:
       description: |
         Entdeckt LLDP- (und optional Cisco-CDP-) Nachbarn per SNMP fuer das
         "Network Topology for Zabbix"-Frontend-Modul. Das Modul zeichnet aus den
-        Nachbar-System-Namen die Verbindungen (Kanten) — Details in LLDP-SETUP.md.
+        Nachbar-System-Namen die Verbindungen (Kanten) - Details in LLDP-SETUP.md.
 
         Verwendung:
           - an SNMP-faehige Switches/Router/Firewalls linken
@@ -27,7 +27,7 @@ zabbix_export:
           description: 'Polling-Intervall der LLDP/CDP-Nachbar-Items.'
         - macro: '{$NT.LLDP.DISCOVERY.INTERVAL}'
           value: 3h
-          description: 'DEPRECATED seit dem walk[]-Umbau: Die LLDP-Discovery haengt jetzt als Dependent-Rule am Walk-Item und folgt {$NT.LLDP.INTERVAL}. Nur noch fuer die (Cisco-)CDP-Discovery in Gebrauch.'
+          description: 'DEPRECATED since the walk[] rework: LLDP discovery is now a dependent rule on the walk item and follows {$NT.LLDP.INTERVAL}. Only still used by the (Cisco) CDP discovery.'
       items:
         - uuid: 084b4a88188c4714abbd5055588aa4ac
           name: 'LLDP: remote systems table (SNMP walk)'
@@ -38,18 +38,18 @@ zabbix_export:
           history: '0'
           value_type: TEXT
           description: |
-            Ein Bulk-Walk ueber die sechs benoetigten Spalten der lldpRemTable
+            One bulk walk over the six needed columns of lldpRemTable
             (LLDP-MIB, 1.0.8802.1.1.2.1.4.1.1): ChassisId (.5), PortId (.7),
             PortDesc (.8), SysName (.9), SysDesc (.10), SysCapEnabled (.12).
 
-            WARUM EIN WALK STATT EINZELNER GETs: Der SNMP-Index der lldpRemTable
-            ist lldpRemTimeMark.lldpRemLocalPortNum.lldpRemIndex. TimeMark ist
-            ein RMON-2-TimeFilter — bei etlichen Implementierungen (FortiGate:
-            neuer Wert bei jedem empfangenen PDU; MikroTik RouterOS: exakte GETs
-            liefern noSuchObject, nur Walks funktionieren) sind instanzgenaue
-            GETs auf diese Tabelle unzuverlaessig. Ein Walk umgeht beides:
-            Discovery und Item-Prototypen haengen als DEPENDENT an diesem Item
-            und parsen den Walk-Text — kein einziger instanzgenauer GET mehr.
+            WHY A WALK INSTEAD OF PER-INSTANCE GETs: The SNMP index of
+            lldpRemTable is lldpRemTimeMark.lldpRemLocalPortNum.lldpRemIndex.
+            TimeMark is an RMON-2 TimeFilter - on several implementations
+            (FortiGate: new value on every received PDU; MikroTik RouterOS:
+            exact GETs return noSuchObject, only walks work) instance-exact
+            GETs on this table are unreliable. A walk sidesteps both:
+            discovery and item prototypes hang off this item as DEPENDENT
+            and parse the walk text - not a single instance-exact GET left.
       discovery_rules:
         - uuid: f388b88ad77144c7b94dfd9c1913713a
           name: 'LLDP neighbor discovery'
@@ -68,28 +68,52 @@ zabbix_export:
             - type: JAVASCRIPT
               parameters:
                 - |
-                  // Der SNMP-Index der lldpRemTable ist
-                  // TimeMark.LocalPort.RemIndex. TimeMark ist volatil
-                  // (FortiGate erhoeht ihn bei jedem empfangenen PDU) und
-                  // fliegt hier raus: {#SNMPINDEX} wird auf 0.Port.RemIndex
-                  // normiert, damit die Item-Keys stabil bleiben. Port und
-                  // RemIndex wandern zusaetzlich in eigene Makros — die
-                  // Prototypen greifen damit per Regex timemark-agnostisch
-                  // auf den Walk-Text zu.
-                  var rows = JSON.parse(value), out = [];
+                  // The SNMP index of lldpRemTable is
+                  // TimeMark.LocalPort.RemIndex. TimeMark is volatile
+                  // (FortiGate bumps it on every received PDU) and is
+                  // dropped here: {#SNMPINDEX} is normalized to
+                  // 0.Port.RemIndex so item keys stay stable. Port and
+                  // RemIndex additionally go into their own macros - the
+                  // prototypes use them to grab values from the walk text
+                  // with a timemark-agnostic regex.
+                  //
+                  // SEEN GUARD: If an agent returns the same row under two
+                  // TimeMarks within ONE walk (TimeFilter semantics - exactly
+                  // what misbehaves on these devices), the normalization
+                  // would emit two LLD rows with an identical {#SNMPINDEX}.
+                  // So per normalized index only the row with the HIGHEST
+                  // TimeMark is kept (newest state wins). Side note: on such
+                  // duplicates the prototype regexes still extract the FIRST
+                  // matching walk line - TimeMark leads the index and walks
+                  // come back in index order, so that is the OLDEST instance.
+                  // Same neighbor row, at worst a briefly stale value -
+                  // cosmetic, but better documented than rediscovered.
+                  var rows = JSON.parse(value), best = {}, order = [];
                   for (var i = 0; i < rows.length; i++) {
                       var r = rows[i];
                       var m = /^(\d+)\.(\d+)\.(\d+)$/.exec(r['{#SNMPINDEX}'] || '');
                       if (!m) continue;
-                      r['{#SNMPINDEX}'] = '0.' + m[2] + '.' + m[3];
+                      var tm = parseInt(m[1], 10);
+                      var idx = '0.' + m[2] + '.' + m[3];
+                      r['{#SNMPINDEX}'] = idx;
                       r['{#NT_PORT}'] = m[2];
                       r['{#NT_REMIDX}'] = m[3];
-                      out.push(r);
+                      if (!Object.prototype.hasOwnProperty.call(best, idx)) {
+                          order.push(idx);
+                          best[idx] = {tm: tm, row: r};
+                      }
+                      else if (tm > best[idx].tm) {
+                          best[idx] = {tm: tm, row: r};
+                      }
+                  }
+                  var out = [];
+                  for (var j = 0; j < order.length; j++) {
+                      out.push(best[order[j]].row);
                   }
                   return JSON.stringify(out);
           description: |
             LLDP-MIB lldpRemSysName (1.0.8802.1.1.2.1.4.1.1.9). Der {#SNMPINDEX}
-            traegt TimeMark.LocalPort.RemIndex — das Modul liest daraus den lokalen
+            traegt TimeMark.LocalPort.RemIndex - das Modul liest daraus den lokalen
             Port. Ueber denselben Index holt es:
 
               .7  lldpRemPortId       Remote-Port (Fallback)
@@ -139,7 +163,7 @@ zabbix_export:
               trends: '0'
               description: |
                 Remote-Port-ID des Nachbarn (lldpRemPortId, OID ...4.1.1.7). Je nach
-                PortIdSubtype ein Interface-Name ("Gi1/0/8") ODER eine MAC-Adresse —
+                PortIdSubtype ein Interface-Name ("Gi1/0/8") ODER eine MAC-Adresse -
                 deshalb liest das Modul bevorzugt lldpRemPortDesc und faellt nur
                 hierauf zurueck. Gleicher {#SNMPINDEX} wie der SysName → dieselbe
                 Nachbar-Zeile (darueber korreliert das Modul).
@@ -180,14 +204,14 @@ zabbix_export:
               history: 7d
               trends: '0'
               description: |
-                Systembeschreibung des Nachbarn (lldpRemSysDesc, OID ...4.1.1.10) —
+                Systembeschreibung des Nachbarn (lldpRemSysDesc, OID ...4.1.1.10) -
                 in der Regel Hersteller, Modell und Firmware im Klartext, z.B.
                 "Cisco IOS Software, C2960X Software ...".
 
                 Fuer UEBERWACHTE Nachbarn ist das Beiwerk. Der Wert zaehlt bei den
                 NICHT ueberwachten: dort kennt das Modul sonst nur den Namen. Mit
                 der Beschreibung wird aus "da haengt sw-edge-03" ein "da haengt ein
-                Cisco-Switch" — und damit ein Hinweis, welches Template passt.
+                Cisco-Switch" - und damit ein Hinweis, welches Template passt.
             - uuid: 36a88ecbea114b5e89f55f7aa684f43d
               name: 'LLDP neighbor capabilities [{#SNMPINDEX}]: {#NT_SYSNAME}'
               type: DEPENDENT
@@ -209,7 +233,7 @@ zabbix_export:
                 ...4.1.1.12) als Bitmaske: Repeater, Bridge, WLAN-AP, Router,
                 Telefon, DOCSIS, Station.
 
-                Sagt, WAS dort haengt, ohne den Namen deuten zu muessen — ein
+                Sagt, WAS dort haengt, ohne den Namen deuten zu muessen - ein
                 Access-Point, ein Telefon und ein Switch sehen sonst gleich aus.
                 Das Modul waehlt darueber das Icon fuer nicht ueberwachte Geraete
                 statt des generischen Platzhalters.
@@ -236,7 +260,7 @@ zabbix_export:
                 Das ist die einzige STABILE Kennung, die LLDP ueber einen nicht
                 ueberwachten Nachbarn liefert. Entdoppelt wird heute ueber den
                 Systemnamen: dasselbe Geraet, von drei Switches gemeldet, wird
-                ueber den Namen zusammengefuehrt — benennt es jemand um, erscheint
+                ueber den Namen zusammengefuehrt - benennt es jemand um, erscheint
                 es als neues Geraet. Ueber die Chassis-ID bleibt die Identitaet
                 erhalten.
         - uuid: 8e6fb294701f48d3a41dd38e59d1fbf0

--- a/templates/nt_lldp_snmp_template.yaml
+++ b/templates/nt_lldp_snmp_template.yaml
@@ -27,14 +27,66 @@ zabbix_export:
           description: 'Polling-Intervall der LLDP/CDP-Nachbar-Items.'
         - macro: '{$NT.LLDP.DISCOVERY.INTERVAL}'
           value: 3h
-          description: 'Discovery-Intervall der Nachbar-Tabellen (aendert sich selten).'
+          description: 'DEPRECATED seit dem walk[]-Umbau: Die LLDP-Discovery haengt jetzt als Dependent-Rule am Walk-Item und folgt {$NT.LLDP.INTERVAL}. Nur noch fuer die (Cisco-)CDP-Discovery in Gebrauch.'
+      items:
+        - uuid: 084b4a88188c4714abbd5055588aa4ac
+          name: 'LLDP: remote systems table (SNMP walk)'
+          type: SNMP_AGENT
+          snmp_oid: 'walk[1.0.8802.1.1.2.1.4.1.1.5,1.0.8802.1.1.2.1.4.1.1.7,1.0.8802.1.1.2.1.4.1.1.8,1.0.8802.1.1.2.1.4.1.1.9,1.0.8802.1.1.2.1.4.1.1.10,1.0.8802.1.1.2.1.4.1.1.12]'
+          key: nt.lldp.walk
+          delay: '{$NT.LLDP.INTERVAL}'
+          history: '0'
+          value_type: TEXT
+          description: |
+            Ein Bulk-Walk ueber die sechs benoetigten Spalten der lldpRemTable
+            (LLDP-MIB, 1.0.8802.1.1.2.1.4.1.1): ChassisId (.5), PortId (.7),
+            PortDesc (.8), SysName (.9), SysDesc (.10), SysCapEnabled (.12).
+
+            WARUM EIN WALK STATT EINZELNER GETs: Der SNMP-Index der lldpRemTable
+            ist lldpRemTimeMark.lldpRemLocalPortNum.lldpRemIndex. TimeMark ist
+            ein RMON-2-TimeFilter — bei etlichen Implementierungen (FortiGate:
+            neuer Wert bei jedem empfangenen PDU; MikroTik RouterOS: exakte GETs
+            liefern noSuchObject, nur Walks funktionieren) sind instanzgenaue
+            GETs auf diese Tabelle unzuverlaessig. Ein Walk umgeht beides:
+            Discovery und Item-Prototypen haengen als DEPENDENT an diesem Item
+            und parsen den Walk-Text — kein einziger instanzgenauer GET mehr.
       discovery_rules:
         - uuid: f388b88ad77144c7b94dfd9c1913713a
           name: 'LLDP neighbor discovery'
-          type: SNMP_AGENT
+          type: DEPENDENT
           key: nt.lldp.rem.discovery
-          snmp_oid: 'discovery[{#NT_SYSNAME},1.0.8802.1.1.2.1.4.1.1.9]'
-          delay: '{$NT.LLDP.DISCOVERY.INTERVAL}'
+          delay: '0'
+          master_item:
+            key: nt.lldp.walk
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#NT_SYSNAME}'
+                - 1.0.8802.1.1.2.1.4.1.1.9
+                - '0'
+              error_handler: DISCARD_VALUE
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Der SNMP-Index der lldpRemTable ist
+                  // TimeMark.LocalPort.RemIndex. TimeMark ist volatil
+                  // (FortiGate erhoeht ihn bei jedem empfangenen PDU) und
+                  // fliegt hier raus: {#SNMPINDEX} wird auf 0.Port.RemIndex
+                  // normiert, damit die Item-Keys stabil bleiben. Port und
+                  // RemIndex wandern zusaetzlich in eigene Makros — die
+                  // Prototypen greifen damit per Regex timemark-agnostisch
+                  // auf den Walk-Text zu.
+                  var rows = JSON.parse(value), out = [];
+                  for (var i = 0; i < rows.length; i++) {
+                      var r = rows[i];
+                      var m = /^(\d+)\.(\d+)\.(\d+)$/.exec(r['{#SNMPINDEX}'] || '');
+                      if (!m) continue;
+                      r['{#SNMPINDEX}'] = '0.' + m[2] + '.' + m[3];
+                      r['{#NT_PORT}'] = m[2];
+                      r['{#NT_REMIDX}'] = m[3];
+                      out.push(r);
+                  }
+                  return JSON.stringify(out);
           description: |
             LLDP-MIB lldpRemSysName (1.0.8802.1.1.2.1.4.1.1.9). Der {#SNMPINDEX}
             traegt TimeMark.LocalPort.RemIndex — das Modul liest daraus den lokalen
@@ -51,11 +103,18 @@ zabbix_export:
           item_prototypes:
             - uuid: 71e0268303f9471796f291808b05293b
               name: 'LLDP neighbor [{#SNMPINDEX}]: {#NT_SYSNAME}'
-              type: SNMP_AGENT
+              type: DEPENDENT
               key: 'lldpRemSysName[{#SNMPINDEX}]'
-              snmp_oid: '1.0.8802.1.1.2.1.4.1.1.9.{#SNMPINDEX}'
               value_type: CHAR
-              delay: '{$NT.LLDP.INTERVAL}'
+              delay: '0'
+              master_item:
+                key: nt.lldp.walk
+              preprocessing:
+                - type: REGEX
+                  parameters:
+                    - '(?m)^\.?1\.0\.8802\.1\.1\.2\.1\.4\.1\.1\.9\.\d+\.{#NT_PORT}\.{#NT_REMIDX} = [A-Za-z0-9-]+: "?(.*?)"?$'
+                    - '\1'
+                  error_handler: DISCARD_VALUE
               history: 7d
               trends: '0'
               description: |
@@ -64,11 +123,18 @@ zabbix_export:
                 ueberwachten Zabbix-Host aufloest.
             - uuid: 33e111c96b2e4ab4a5e0047ba739d05f
               name: 'LLDP neighbor port-id [{#SNMPINDEX}]: {#NT_SYSNAME}'
-              type: SNMP_AGENT
+              type: DEPENDENT
               key: 'lldpRemPortId[{#SNMPINDEX}]'
-              snmp_oid: '1.0.8802.1.1.2.1.4.1.1.7.{#SNMPINDEX}'
               value_type: CHAR
-              delay: '{$NT.LLDP.INTERVAL}'
+              delay: '0'
+              master_item:
+                key: nt.lldp.walk
+              preprocessing:
+                - type: REGEX
+                  parameters:
+                    - '(?m)^\.?1\.0\.8802\.1\.1\.2\.1\.4\.1\.1\.7\.\d+\.{#NT_PORT}\.{#NT_REMIDX} = [A-Za-z0-9-]+: "?(.*?)"?$'
+                    - '\1'
+                  error_handler: DISCARD_VALUE
               history: 7d
               trends: '0'
               description: |
@@ -79,11 +145,18 @@ zabbix_export:
                 Nachbar-Zeile (darueber korreliert das Modul).
             - uuid: 296934a9b576433095c087dbdeb383e6
               name: 'LLDP neighbor port-desc [{#SNMPINDEX}]: {#NT_SYSNAME}'
-              type: SNMP_AGENT
+              type: DEPENDENT
               key: 'lldpRemPortDesc[{#SNMPINDEX}]'
-              snmp_oid: '1.0.8802.1.1.2.1.4.1.1.8.{#SNMPINDEX}'
               value_type: CHAR
-              delay: '{$NT.LLDP.INTERVAL}'
+              delay: '0'
+              master_item:
+                key: nt.lldp.walk
+              preprocessing:
+                - type: REGEX
+                  parameters:
+                    - '(?m)^\.?1\.0\.8802\.1\.1\.2\.1\.4\.1\.1\.8\.\d+\.{#NT_PORT}\.{#NT_REMIDX} = [A-Za-z0-9-]+: "?(.*?)"?$'
+                    - '\1'
+                  error_handler: DISCARD_VALUE
               history: 7d
               trends: '0'
               description: |
@@ -92,11 +165,18 @@ zabbix_export:
                 Quelle fuers Port-zu-Port-Label am Nachbar-Ende.
             - uuid: ae103ab500594d00bc368f47749fac2e
               name: 'LLDP neighbor sys-desc [{#SNMPINDEX}]: {#NT_SYSNAME}'
-              type: SNMP_AGENT
+              type: DEPENDENT
               key: 'lldpRemSysDesc[{#SNMPINDEX}]'
-              snmp_oid: '1.0.8802.1.1.2.1.4.1.1.10.{#SNMPINDEX}'
               value_type: CHAR
-              delay: '{$NT.LLDP.INTERVAL}'
+              delay: '0'
+              master_item:
+                key: nt.lldp.walk
+              preprocessing:
+                - type: REGEX
+                  parameters:
+                    - '(?m)^\.?1\.0\.8802\.1\.1\.2\.1\.4\.1\.1\.10\.\d+\.{#NT_PORT}\.{#NT_REMIDX} = [A-Za-z0-9-]+: "?(.*?)"?$'
+                    - '\1'
+                  error_handler: DISCARD_VALUE
               history: 7d
               trends: '0'
               description: |
@@ -110,11 +190,18 @@ zabbix_export:
                 Cisco-Switch" — und damit ein Hinweis, welches Template passt.
             - uuid: 36a88ecbea114b5e89f55f7aa684f43d
               name: 'LLDP neighbor capabilities [{#SNMPINDEX}]: {#NT_SYSNAME}'
-              type: SNMP_AGENT
+              type: DEPENDENT
               key: 'lldpRemSysCapEnabled[{#SNMPINDEX}]'
-              snmp_oid: '1.0.8802.1.1.2.1.4.1.1.12.{#SNMPINDEX}'
               value_type: CHAR
-              delay: '{$NT.LLDP.INTERVAL}'
+              delay: '0'
+              master_item:
+                key: nt.lldp.walk
+              preprocessing:
+                - type: REGEX
+                  parameters:
+                    - '(?m)^\.?1\.0\.8802\.1\.1\.2\.1\.4\.1\.1\.12\.\d+\.{#NT_PORT}\.{#NT_REMIDX} = [A-Za-z0-9-]+: "?(.*?)"?$'
+                    - '\1'
+                  error_handler: DISCARD_VALUE
               history: 7d
               trends: '0'
               description: |
@@ -128,11 +215,18 @@ zabbix_export:
                 statt des generischen Platzhalters.
             - uuid: e62a93c7791f47aa8f49bb21e7da9136
               name: 'LLDP neighbor chassis-id [{#SNMPINDEX}]: {#NT_SYSNAME}'
-              type: SNMP_AGENT
+              type: DEPENDENT
               key: 'lldpRemChassisId[{#SNMPINDEX}]'
-              snmp_oid: '1.0.8802.1.1.2.1.4.1.1.5.{#SNMPINDEX}'
               value_type: CHAR
-              delay: '{$NT.LLDP.INTERVAL}'
+              delay: '0'
+              master_item:
+                key: nt.lldp.walk
+              preprocessing:
+                - type: REGEX
+                  parameters:
+                    - '(?m)^\.?1\.0\.8802\.1\.1\.2\.1\.4\.1\.1\.5\.\d+\.{#NT_PORT}\.{#NT_REMIDX} = [A-Za-z0-9-]+: "?(.*?)"?$'
+                    - '\1'
+                  error_handler: DISCARD_VALUE
               history: 7d
               trends: '0'
               description: |


### PR DESCRIPTION
# templates: rework LLDP neighbor polling to walk[] + dependent items (fixes FortiGate timemark churn and MikroTik noSuchObject)

Fixes #3, fixes #4.

## Problem

`nt_lldp_snmp_template.yaml` discovers `lldpRemTable` rows and then polls each instance with an exact SNMP GET at `1.0.8802.1.1.2.1.4.1.1.X.{#SNMPINDEX}`, where `{#SNMPINDEX}` = `lldpRemTimeMark.lldpRemLocalPortNum.lldpRemIndex`.

That breaks on real devices in two independent ways:

- **FortiGate**: `lldpRemTimeMark` rolls on every received LLDP PDU, so the discovered index is stale within seconds. Items only work if discovery+polling intervals are cranked down to seconds.
- **MikroTik RouterOS**: the agent answers walks on the LLDP subtree but returns `noSuchObject` for exact-instance GETs - discovery creates items, all of them fail permanently.

## Change

Same pattern the official Zabbix templates use since 6.4:

- **New master item** `nt.lldp.walk`: `walk[]` over the six needed lldpRemTable columns (`.5 .7 .8 .9 .10 .12`), polled at `{$NT.LLDP.INTERVAL}`, `history: 0`.
- **`LLDP neighbor discovery` → DEPENDENT** on the walk, preprocessing:
  1. `SNMP walk to JSON` on column `.9` (`{#NT_SYSNAME}`),
  2. JavaScript: normalize `{#SNMPINDEX}` from `TimeMark.Port.RemIndex` to `0.Port.RemIndex`, add `{#NT_PORT}` and `{#NT_REMIDX}`.
- **All six item prototypes → DEPENDENT** on the walk, each extracting its value with a timemark-agnostic regex (`...\.<col>\.\d+\.{#NT_PORT}\.{#NT_REMIDX} = TYPE: value`), `error_handler: DISCARD_VALUE` so vanished neighbors don't flip items to unsupported (LLD lost-resource lifetime cleans them up as before).
- `{$NT.LLDP.DISCOVERY.INTERVAL}` marked deprecated in its description (still used by the CDP rule, which is unchanged - Cisco agents answer exact GETs fine).

## Compatibility with the module

No PHP/JS changes needed:

- Item **keys keep the exact same shape** (`lldpRemSysName[0.24.1]`): `LldpEdgeBuilder` extracts the local port with `^\d+\.(\d+)\.\d+$` (middle part) - a literal `0` timemark satisfies it.
- Entity **UUIDs and keys are preserved**, so importing the template upgrades discovery rule and prototypes in place; existing item history is kept.
- SysName/port/meta correlation over the shared bracket index is unchanged (all prototypes of one LLD row share `0.Port.RemIndex`).
- Hex values (`lldpRemChassisId`, `lldpRemSysCapEnabled`) arrive as `Hex-STRING` hex bytes, which the module's existing hex handling (`MetricExtractor`) already parses.

## Side benefits

- One bulk walk per host per interval instead of 6×N GETs.
- Discovery is now a free by-product of every poll - new neighbors appear within one `{$NT.LLDP.INTERVAL}` instead of one `{$NT.LLDP.DISCOVERY.INTERVAL}`.
- `tools/check-templates.mjs` passes.

## Testing

- YAML validated + repo CI (`node tools/check-templates.mjs`) green.
- LLD JavaScript step and per-column extraction regexes exercised against synthetic walk output with FortiGate-style rolling timemarks, quoted and unquoted STRING values, and Hex-STRING values; missing rows correctly discard.
- (Please verify on live FortiGate + MikroTik before merge - happy to provide walk captures.)